### PR TITLE
Initialize Firebase + Next.js skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - name: Install deps
+        run: pnpm i --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
+      - name: Test
+        run: pnpm test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy to Firebase
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - name: Install deps
+        run: pnpm i --frozen-lockfile
+      - name: Build
+        run: pnpm build
+      - name: Deploy to Firebase
+        uses: FirebaseExtended/action-hosting-deploy@v1
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          channelId: live
+          projectId: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# bellum-react-front
+# Bellum Monorepo
+
+Skeleton monorepo using Next.js 14 and Firebase with pnpm workspaces.

--- a/apps/functions/esbuild.config.mjs
+++ b/apps/functions/esbuild.config.mjs
@@ -1,0 +1,11 @@
+import { build } from "esbuild";
+
+build({
+  entryPoints: ["src/index.ts"],
+  outdir: "dist",
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  sourcemap: true,
+  target: "es2022"
+}).catch(() => process.exit(1));

--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "functions",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsup src/index.ts --out-dir dist --format esm --minify",
+    "lint": "eslint . --ext .ts"
+  },
+  "dependencies": {
+    "firebase-admin": "^12.0.0",
+    "firebase-functions": "^4.1.1"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/apps/functions/src/api/helloWorld.ts
+++ b/apps/functions/src/api/helloWorld.ts
@@ -1,0 +1,5 @@
+import { onRequest } from "firebase-functions/v2/https";
+
+export const helloWorld = onRequest((_, res) => {
+  res.send("Hello World !");
+});

--- a/apps/functions/src/index.ts
+++ b/apps/functions/src/index.ts
@@ -1,0 +1,18 @@
+import { onRequest } from "firebase-functions/v2/https";
+import { initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+initializeApp();
+const db = getFirestore();
+
+export const nextServer = onRequest(
+  { timeoutSeconds: 15, memory: "1GiB", region: "europe-west1" },
+  async (req, res) => {
+    // 🛈 Ce handler est remplacé par Next.js lors du déploiement (adapter-firebase).
+    res.status(200).send("Next.js server placeholder");
+  }
+);
+
+export const helloWorld = onRequest((req, res) => {
+  res.send("Hello World !");
+});

--- a/apps/functions/tsconfig.json
+++ b/apps/functions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "esnext",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "module": "esnext",
+    "lib": ["esnext"],
+    "noEmit": false,
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: true,
+    appDir: true
+  },
+  images: {
+    domains: [] // TODO ajoute tes domaines d’images distantes
+  }
+};
+export default nextConfig;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,12 @@
+import "@/styles/globals.css";
+import { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="fr">
+      <body className="min-h-screen bg-background antialiased">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,0 +1,7 @@
+export default function HomePage() {
+  return (
+    <main className="flex items-center justify-center h-screen">
+      <h1 className="text-4xl font-bold">Hello Firebase + Next.js !</h1>
+    </main>
+  );
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,10 @@
+import { type Config } from "tailwindcss";
+import { shadcnPlugin } from "@shadcn/ui";
+
+export default {
+  content: ["./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {}
+  },
+  plugins: [shadcnPlugin]
+} satisfies Config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "jsx": "preserve",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "paths": {
+      "@ui/*": ["../../packages/ui/src/*"],
+      "@utils/*": ["../../packages/utils/src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/infra/emulators.json
+++ b/infra/emulators.json
@@ -1,0 +1,9 @@
+{
+  "emulators": {
+    "auth": { "port": 9099 },
+    "functions": { "port": 5001 },
+    "firestore": { "port": 8080 },
+    "hosting": { "port": 5000 },
+    "ui": { "enabled": true }
+  }
+}

--- a/infra/firebase.json
+++ b/infra/firebase.json
@@ -1,0 +1,24 @@
+{
+  "functions": {
+    "source": "apps/functions",
+    "runtime": "nodejs20"
+  },
+  "hosting": {
+    "source": "apps/web",
+    "public": "apps/web/out",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "**",
+        "function": "nextServer"
+      }
+    ]
+  },
+  "emulators": {
+    "functions": { "port": 5001 },
+    "firestore": { "port": 8080 },
+    "auth": { "port": 9099 },
+    "hosting": { "port": 5000 },
+    "ui": { "enabled": true }
+  }
+}

--- a/infra/firestore.rules
+++ b/infra/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/infra/storage.rules
+++ b/infra/storage.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "my-app",
+  "private": true,
+  "packageManager": "pnpm@9.1.0",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev": "turbo run dev --parallel",
+    "build": "turbo run build",
+    "lint": "turbo run lint",
+    "test": "turbo run test",
+    "deploy": "firebase deploy"
+  },
+  "devDependencies": {
+    "turbo": "^1.13.3",
+    "firebase-tools": "^14.10.1"
+  }
+}

--- a/packages/config/eslint/index.cjs
+++ b/packages/config/eslint/index.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  env: {
+    node: true,
+    es2022: true
+  }
+};

--- a/packages/config/jest/jest.config.cjs
+++ b/packages/config/jest/jest.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: "node",
+  moduleFileExtensions: ["ts", "tsx", "js"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["ts-jest", { tsconfig: "../../tsconfig.base.json" }]
+  }
+};

--- a/packages/config/prettier/index.cjs
+++ b/packages/config/prettier/index.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  semi: true,
+  singleQuote: false,
+  trailingComma: "none"
+};

--- a/packages/config/tsconfig/base.json
+++ b/packages/config/tsconfig/base.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@my/ui",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --out-dir dist --format esm --dts",
+    "dev": "tsc -w",
+    "lint": "eslint src --ext .ts,.tsx"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "react": "^18.0.0",
+    "eslint": "^8.0.0"
+  }
+}

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,0 +1,16 @@
+import { ButtonHTMLAttributes } from "react";
+import { twMerge } from "tailwind-merge";
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({ className, ...rest }: Props) {
+  return (
+    <button
+      className={twMerge(
+        "inline-flex items-center rounded-2xl px-4 py-2 font-medium bg-primary text-white shadow",
+        className
+      )}
+      {...rest}
+    />
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,1 @@
+export { Button } from "./Button";

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "declarationDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@my/utils",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --out-dir dist --format esm --dts",
+    "dev": "tsc -w",
+    "lint": "eslint src --ext .ts"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "eslint": "^8.0.0"
+  }
+}

--- a/packages/utils/src/firebaseClient.ts
+++ b/packages/utils/src/firebaseClient.ts
@@ -1,0 +1,14 @@
+import { initializeApp } from "firebase/app";
+import { getAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  // … autres clés si nécessaire
+};
+
+export const firebaseApp = initializeApp(firebaseConfig);
+export const auth = getAuth(firebaseApp);
+export const db = getFirestore(firebaseApp);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./firebaseClient";

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@ui/*": ["packages/ui/src/*"],
+      "@utils/*": ["packages/utils/src/*"]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "dev": {
+      "cache": false
+    },
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**"]
+    },
+    "lint": {},
+    "test": {}
+  }
+}


### PR DESCRIPTION
## Summary
- bootstrap a monorepo with Next.js and Firebase
- add shared package configs and utility packages
- set up example Cloud Functions
- add basic CI and deploy workflows

## Testing
- `pnpm test` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_6868e2e4e6ec8332b1732aeaf89c6bb8