### PR TITLE
Add Firebase auth integration

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,21 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const session = request.cookies.get("session");
+  const isAuthPage = request.nextUrl.pathname.startsWith("/login") ||
+    request.nextUrl.pathname.startsWith("/signup");
+
+  if (!session && !isAuthPage && !request.nextUrl.pathname.startsWith("/api")) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  if (session && isAuthPage) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/:path*"
+};

--- a/apps/web/src/app/api/login/route.ts
+++ b/apps/web/src/app/api/login/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  const { idToken } = await request.json();
+  if (!idToken) {
+    return NextResponse.json({ error: "Missing token" }, { status: 400 });
+  }
+
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set({
+    name: "session",
+    value: idToken,
+    httpOnly: true,
+    maxAge: 60 * 60 * 24 * 7,
+    path: "/"
+  });
+  return response;
+}

--- a/apps/web/src/app/api/logout/route.ts
+++ b/apps/web/src/app/api/logout/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(_: NextRequest) {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set({
+    name: "session",
+    value: "",
+    httpOnly: true,
+    maxAge: 0,
+    path: "/"
+  });
+  return response;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,11 +1,12 @@
 import "@/styles/globals.css";
 import { ReactNode } from "react";
+import { AuthProvider } from "./providers/AuthProvider";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="fr">
       <body className="min-h-screen bg-background antialiased">
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, FormEvent } from "react";
+import { useAuth } from "../providers/AuthProvider";
+import { Input } from "@ui/Input";
+import { Button } from "@ui/Button";
+
+export default function LoginPage() {
+  const { signIn, signInWithGoogle, user, loading } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  useEffect(() => {
+    if (user) router.replace("/");
+  }, [user, router]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await signIn(email, password);
+  };
+
+  return (
+    <main className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-xs">
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <Button type="submit" disabled={loading} className="w-full">
+          Sign in
+        </Button>
+        <Button type="button" onClick={signInWithGoogle} className="w-full">
+          Sign in with Google
+        </Button>
+      </form>
+    </main>
+  );
+}

--- a/apps/web/src/app/providers/AuthProvider.tsx
+++ b/apps/web/src/app/providers/AuthProvider.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import {
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut as firebaseSignOut,
+  signInWithPopup,
+  GoogleAuthProvider,
+  User
+} from "firebase/auth";
+import { auth } from "@utils/firebaseClient";
+
+interface AuthContextValue {
+  user: User | null;
+  loading: boolean;
+  signUp: (email: string, password: string) => Promise<void>;
+  signIn: (email: string, password: string) => Promise<void>;
+  signInWithGoogle: () => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+      setUser(firebaseUser);
+      setLoading(false);
+      if (firebaseUser) {
+        const token = await firebaseUser.getIdToken();
+        await fetch("/api/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ idToken: token })
+        });
+      } else {
+        await fetch("/api/logout");
+      }
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const signUp = async (email: string, password: string) => {
+    setLoading(true);
+    await createUserWithEmailAndPassword(auth, email, password);
+    setLoading(false);
+  };
+
+  const signIn = async (email: string, password: string) => {
+    setLoading(true);
+    await signInWithEmailAndPassword(auth, email, password);
+    setLoading(false);
+  };
+
+  const signInWithGoogle = async () => {
+    setLoading(true);
+    const provider = new GoogleAuthProvider();
+    await signInWithPopup(auth, provider);
+    setLoading(false);
+  };
+
+  const signOut = async () => {
+    setLoading(true);
+    await firebaseSignOut(auth);
+    setLoading(false);
+  };
+
+  const value: AuthContextValue = {
+    user,
+    loading,
+    signUp,
+    signIn,
+    signInWithGoogle,
+    signOut
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, FormEvent } from "react";
+import { useAuth } from "../providers/AuthProvider";
+import { Input } from "@ui/Input";
+import { Button } from "@ui/Button";
+
+export default function SignupPage() {
+  const { signUp, user, loading } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  useEffect(() => {
+    if (user) router.replace("/");
+  }, [user, router]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await signUp(email, password);
+  };
+
+  return (
+    <main className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-xs">
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <Button type="submit" disabled={loading} className="w-full">
+          Sign up
+        </Button>
+      </form>
+    </main>
+  );
+}

--- a/packages/ui/src/Input.tsx
+++ b/packages/ui/src/Input.tsx
@@ -1,0 +1,18 @@
+import { forwardRef, InputHTMLAttributes } from "react";
+import { twMerge } from "tailwind-merge";
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={twMerge(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Input.displayName = "Input";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,2 @@
 export { Button } from "./Button";
+export { Input } from "./Input";

--- a/packages/utils/src/firebaseClient.ts
+++ b/packages/utils/src/firebaseClient.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
+import { getAuth, browserLocalPersistence, setPersistence } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
@@ -7,8 +7,9 @@ const firebaseConfig = {
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
   projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
   // … autres clés si nécessaire
-};
+} as const;
 
 export const firebaseApp = initializeApp(firebaseConfig);
 export const auth = getAuth(firebaseApp);
+setPersistence(auth, browserLocalPersistence);
 export const db = getFirestore(firebaseApp);


### PR DESCRIPTION
## Summary
- add Input component to UI package
- configure Firebase client with local persistence
- create auth context provider for Next.js app
- implement login and signup pages
- store session token in cookie via API routes
- protect routes via Next.js middleware

## Testing
- `pnpm lint` *(fails: fetch failed - no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6868e5493bd48332a8a861d53e2fa40d