### PR TITLE
Add chat UI

### DIFF
--- a/apps/web/src/app/chat/ChatInput.tsx
+++ b/apps/web/src/app/chat/ChatInput.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState } from 'react';
+import { Button } from '@ui/Button';
+import { useChat } from '../providers/ChatProvider';
+
+export default function ChatInput() {
+  const { sendMessage, loading } = useChat();
+  const [text, setText] = useState('');
+
+  const handleSend = async () => {
+    if (!text.trim()) return;
+    await sendMessage(text.trim());
+    setText('');
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void handleSend();
+    }
+  };
+
+  return (
+    <div className="border-t p-4 flex gap-2">
+      <textarea
+        className="flex-1 resize-none rounded-md border px-3 py-2 text-sm"
+        rows={1}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={onKeyDown}
+        disabled={loading}
+      />
+      <Button type="button" onClick={handleSend} disabled={loading || !text.trim()}>
+        Send
+      </Button>
+    </div>
+  );
+}
+

--- a/apps/web/src/app/chat/ChatWindow.tsx
+++ b/apps/web/src/app/chat/ChatWindow.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useChat } from '../providers/ChatProvider';
+import { useEffect, useRef } from 'react';
+
+export default function ChatWindow() {
+  const { messages } = useChat();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el) {
+      el.scrollTo({ top: el.scrollHeight });
+    }
+  }, [messages]);
+
+  return (
+    <div ref={containerRef} className="flex-1 overflow-y-auto p-4 space-y-2">
+      {messages.map((m) => (
+        <div
+          key={m.id}
+          className={`max-w-prose rounded-lg px-3 py-2 whitespace-pre-wrap ${m.role === 'user' ? 'bg-primary text-white ml-auto' : 'bg-gray-200 text-gray-900 mr-auto'}`}
+        >
+          {m.content}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -1,0 +1,22 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { ChatProvider } from '../providers/ChatProvider';
+import ChatWindow from './ChatWindow';
+import ChatInput from './ChatInput';
+
+export default function ChatPage() {
+  const session = cookies().get('session');
+  if (!session?.value) {
+    redirect('/login');
+  }
+
+  return (
+    <ChatProvider>
+      <main className="flex flex-col h-screen">
+        <ChatWindow />
+        <ChatInput />
+      </main>
+    </ChatProvider>
+  );
+}
+

--- a/apps/web/src/app/providers/ChatProvider.tsx
+++ b/apps/web/src/app/providers/ChatProvider.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { createContext, useContext, useEffect, useRef, useState, ReactNode } from 'react';
+import { z } from 'zod';
+
+export type ChatMessage = {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  createdAt: string;
+};
+
+interface ChatContextValue {
+  messages: ChatMessage[];
+  loading: boolean;
+  sendMessage: (text: string) => Promise<void>;
+}
+
+const ChatContext = createContext<ChatContextValue | undefined>(undefined);
+
+const messageSchema = z.object({
+  id: z.string(),
+  role: z.enum(['user', 'assistant']),
+  content: z.string(),
+  createdAt: z.string()
+});
+const messagesSchema = z.array(messageSchema);
+
+export function ChatProvider({ children }: { children: ReactNode }) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loading, setLoading] = useState(false);
+  const eventRef = useRef<EventSource | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const cleanup = () => {
+    if (eventRef.current) {
+      eventRef.current.close();
+      eventRef.current = null;
+    }
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/api/chat');
+        const data = await res.json();
+        const parsed = messagesSchema.parse(data);
+        setMessages(parsed);
+      } catch (err) {
+        console.error('Failed to load chat messages', err);
+      }
+    })();
+    return cleanup;
+  }, []);
+
+  const startPolling = () => {
+    const start = Date.now();
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await fetch('/api/chat');
+        const data = await res.json();
+        const parsed = messagesSchema.parse(data);
+        setMessages(parsed);
+        const last = parsed[parsed.length - 1];
+        if (last && last.role === 'assistant') {
+          setLoading(false);
+          cleanup();
+        }
+      } catch (err) {
+        console.error('Polling error', err);
+      }
+      if (Date.now() - start > 60000) {
+        setLoading(false);
+        cleanup();
+      }
+    }, 2000);
+  };
+
+  const sendMessage = async (text: string) => {
+    cleanup();
+    const userMsg: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: text,
+      createdAt: new Date().toISOString()
+    };
+    const assistantMsg: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'assistant',
+      content: '',
+      createdAt: new Date().toISOString()
+    };
+    setMessages(prev => [...prev, userMsg, assistantMsg]);
+    setLoading(true);
+    try {
+      await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text })
+      });
+    } catch (err) {
+      console.error('Failed to send message', err);
+    }
+
+    const updateAssistant = (content: string) =>
+      setMessages(prev =>
+        prev.map(m => (m.id === assistantMsg.id ? { ...m, content } : m))
+      );
+
+    if (typeof window !== 'undefined' && 'EventSource' in window) {
+      try {
+        const es = new EventSource('/api/chat/stream');
+        eventRef.current = es;
+        es.onmessage = ev => {
+          if (ev.data === '[DONE]') {
+            setLoading(false);
+            cleanup();
+          } else {
+            assistantMsg.content += ev.data;
+            updateAssistant(assistantMsg.content);
+          }
+        };
+        es.onerror = () => {
+          cleanup();
+          startPolling();
+        };
+      } catch {
+        startPolling();
+      }
+    } else {
+      startPolling();
+    }
+  };
+
+  const value: ChatContextValue = { messages, loading, sendMessage };
+
+  return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
+}
+
+export function useChat() {
+  const ctx = useContext(ChatContext);
+  if (!ctx) throw new Error('useChat must be used within ChatProvider');
+  return ctx;
+}
+


### PR DESCRIPTION
## Summary
- add `ChatProvider` context with SSE or polling
- create `ChatWindow` and `ChatInput` components
- add `/chat` page with auth check

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6868e8e1b3fc833297e942b722e141c1